### PR TITLE
added --grpc-query-address to allow for remote debug crd validation

### DIFF
--- a/internal/controllers/controllers.go
+++ b/internal/controllers/controllers.go
@@ -42,6 +42,5 @@ func Setup(mgr ctrl.Manager, option controller.Options, nddcopts *shared.NddCont
 		}
 		eventChans[gvk] = eventChan
 	}
-
 	return eventChans, nil
 }

--- a/internal/controllers/controllers.go
+++ b/internal/controllers/controllers.go
@@ -17,22 +17,18 @@ limitations under the License.
 package controllers
 
 import (
-	"time"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
-	"github.com/yndd/ndd-runtime/pkg/logging"
-
-	"github.com/yndd/ndd-yang/pkg/yentry"
 	"github.com/yndd/nddo-ipam/internal/controllers/ipam"
+	"github.com/yndd/nddo-ipam/internal/shared"
 )
 
 // Setup package controllers.
-func Setup(mgr ctrl.Manager, option controller.Options, l logging.Logger, poll time.Duration, namespace string, rs *yentry.Entry) (map[string]chan event.GenericEvent, error) {
+func Setup(mgr ctrl.Manager, option controller.Options, nddcopts *shared.NddControllerOptions) (map[string]chan event.GenericEvent, error) {
 	eventChans := make(map[string]chan event.GenericEvent)
-	for _, setup := range []func(ctrl.Manager, controller.Options, logging.Logger, time.Duration, string, *yentry.Entry) (string, chan event.GenericEvent, error){
+	for _, setup := range []func(ctrl.Manager, controller.Options, *shared.NddControllerOptions) (string, chan event.GenericEvent, error){
 		ipam.SetupIpam,
 		ipam.SetupIpamTenant,
 		ipam.SetupIpamTenantNetworkinstance,
@@ -40,7 +36,7 @@ func Setup(mgr ctrl.Manager, option controller.Options, l logging.Logger, poll t
 		ipam.SetupIpamTenantNetworkinstanceIprange,
 		ipam.SetupIpamTenantNetworkinstanceIpaddress,
 	} {
-		gvk, eventChan, err := setup(mgr, option, l, poll, namespace, rs)
+		gvk, eventChan, err := setup(mgr, option, nddcopts)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/controllers/ipam/ipamipamtenant_controller.go
+++ b/internal/controllers/ipam/ipamipamtenant_controller.go
@@ -73,8 +73,8 @@ func SetupIpamTenant(mgr ctrl.Manager, o controller.Options, nddcopts *shared.Nd
 	y := initYangIpamTenant()
 
 	r := managed.NewReconciler(mgr,
-		resource.ManagedKind(ipamv1alpha1.IpamGroupVersionKind),
-		managed.WithExternalConnecter(&connectorIpam{
+		resource.ManagedKind(ipamv1alpha1.IpamTenantGroupVersionKind),
+		managed.WithExternalConnecter(&connectorIpamTenant{
 			log:              nddcopts.Logger,
 			kube:             mgr.GetClient(),
 			usage:            resource.NewNetworkNodeUsageTracker(mgr.GetClient(), &ndrv1.NetworkNodeUsage{}),
@@ -85,7 +85,7 @@ func SetupIpamTenant(mgr ctrl.Manager, o controller.Options, nddcopts *shared.Nd
 		},
 		),
 		managed.WithParser(nddcopts.Logger),
-		managed.WithValidator(&validatorIpam{
+		managed.WithValidator(&validatorIpamTenant{
 			log:        nddcopts.Logger,
 			rootSchema: nddcopts.Yentry,
 			y:          y,

--- a/internal/controllers/ipam/ipamipamtenantnetworkinstance_controller.go
+++ b/internal/controllers/ipam/ipamipamtenantnetworkinstance_controller.go
@@ -97,8 +97,8 @@ func SetupIpamTenantNetworkinstance(mgr ctrl.Manager, o controller.Options, nddc
 	y := initYangIpamTenantNetworkinstance()
 
 	r := managed.NewReconciler(mgr,
-		resource.ManagedKind(ipamv1alpha1.IpamGroupVersionKind),
-		managed.WithExternalConnecter(&connectorIpam{
+		resource.ManagedKind(ipamv1alpha1.IpamTenantNetworkinstanceGroupVersionKind),
+		managed.WithExternalConnecter(&connectorIpamTenantNetworkinstance{
 			log:              nddcopts.Logger,
 			kube:             mgr.GetClient(),
 			usage:            resource.NewNetworkNodeUsageTracker(mgr.GetClient(), &ndrv1.NetworkNodeUsage{}),
@@ -109,7 +109,7 @@ func SetupIpamTenantNetworkinstance(mgr ctrl.Manager, o controller.Options, nddc
 		},
 		),
 		managed.WithParser(nddcopts.Logger),
-		managed.WithValidator(&validatorIpam{
+		managed.WithValidator(&validatorIpamTenantNetworkinstance{
 			log:        nddcopts.Logger,
 			rootSchema: nddcopts.Yentry,
 			y:          y,

--- a/internal/controllers/ipam/ipamipamtenantnetworkinstanceipaddress_controller.go
+++ b/internal/controllers/ipam/ipamipamtenantnetworkinstanceipaddress_controller.go
@@ -97,8 +97,8 @@ func SetupIpamTenantNetworkinstanceIpaddress(mgr ctrl.Manager, o controller.Opti
 	y := initYangIpamTenantNetworkinstanceIpaddress()
 
 	r := managed.NewReconciler(mgr,
-		resource.ManagedKind(ipamv1alpha1.IpamGroupVersionKind),
-		managed.WithExternalConnecter(&connectorIpam{
+		resource.ManagedKind(ipamv1alpha1.IpamTenantNetworkinstanceIpaddressGroupVersionKind),
+		managed.WithExternalConnecter(&connectorIpamTenantNetworkinstanceIpaddress{
 			log:              nddcopts.Logger,
 			kube:             mgr.GetClient(),
 			usage:            resource.NewNetworkNodeUsageTracker(mgr.GetClient(), &ndrv1.NetworkNodeUsage{}),
@@ -109,7 +109,7 @@ func SetupIpamTenantNetworkinstanceIpaddress(mgr ctrl.Manager, o controller.Opti
 		},
 		),
 		managed.WithParser(nddcopts.Logger),
-		managed.WithValidator(&validatorIpam{
+		managed.WithValidator(&validatorIpamTenantNetworkinstanceIpaddress{
 			log:        nddcopts.Logger,
 			rootSchema: nddcopts.Yentry,
 			y:          y,

--- a/internal/controllers/ipam/ipamipamtenantnetworkinstanceipaddress_controller.go
+++ b/internal/controllers/ipam/ipamipamtenantnetworkinstanceipaddress_controller.go
@@ -47,6 +47,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	ipamv1alpha1 "github.com/yndd/nddo-ipam/apis/ipam/v1alpha1"
+	"github.com/yndd/nddo-ipam/internal/shared"
 )
 
 const (
@@ -87,7 +88,7 @@ var resourceRefPathsIpamTenantNetworkinstanceIpaddress = []*gnmi.Path{
 //var externalLeafRefIpamTenantNetworkinstanceIpaddress = []*parser.LeafRefGnmi{}
 
 // SetupIpamTenantNetworkinstanceIpaddress adds a controller that reconciles IpamTenantNetworkinstanceIpaddresss.
-func SetupIpamTenantNetworkinstanceIpaddress(mgr ctrl.Manager, o controller.Options, l logging.Logger, poll time.Duration, namespace string, rs *yentry.Entry) (string, chan cevent.GenericEvent, error) {
+func SetupIpamTenantNetworkinstanceIpaddress(mgr ctrl.Manager, o controller.Options, nddcopts *shared.NddControllerOptions) (string, chan cevent.GenericEvent, error) {
 
 	name := managed.ControllerName(ipamv1alpha1.IpamTenantNetworkinstanceIpaddressGroupKind)
 
@@ -96,22 +97,25 @@ func SetupIpamTenantNetworkinstanceIpaddress(mgr ctrl.Manager, o controller.Opti
 	y := initYangIpamTenantNetworkinstanceIpaddress()
 
 	r := managed.NewReconciler(mgr,
-		resource.ManagedKind(ipamv1alpha1.IpamTenantNetworkinstanceIpaddressGroupVersionKind),
-		managed.WithExternalConnecter(&connectorIpamTenantNetworkinstanceIpaddress{
-			log:         l,
-			kube:        mgr.GetClient(),
-			usage:       resource.NewNetworkNodeUsageTracker(mgr.GetClient(), &ndrv1.NetworkNodeUsage{}),
-			rootSchema:  rs,
-			y:           y,
-			newClientFn: target.NewTarget},
+		resource.ManagedKind(ipamv1alpha1.IpamGroupVersionKind),
+		managed.WithExternalConnecter(&connectorIpam{
+			log:              nddcopts.Logger,
+			kube:             mgr.GetClient(),
+			usage:            resource.NewNetworkNodeUsageTracker(mgr.GetClient(), &ndrv1.NetworkNodeUsage{}),
+			rootSchema:       nddcopts.Yentry,
+			y:                y,
+			newClientFn:      target.NewTarget,
+			grpcQueryAddress: nddcopts.GrpcQueryAddress,
+		},
 		),
-		managed.WithParser(l),
-		managed.WithValidator(&validatorIpamTenantNetworkinstanceIpaddress{
-			log:        l,
-			rootSchema: rs,
+		managed.WithParser(nddcopts.Logger),
+		managed.WithValidator(&validatorIpam{
+			log:        nddcopts.Logger,
+			rootSchema: nddcopts.Yentry,
 			y:          y,
-			parser:     *parser.NewParser(parser.WithLogger(l))}),
-		managed.WithLogger(l.WithValues("controller", name)),
+			parser:     *parser.NewParser(parser.WithLogger(nddcopts.Logger))},
+		),
+		managed.WithLogger(nddcopts.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
 
 	return ipamv1alpha1.IpamTenantNetworkinstanceIpaddressGroupKind, events, ctrl.NewControllerManagedBy(mgr).
@@ -321,6 +325,7 @@ type connectorIpamTenantNetworkinstanceIpaddress struct {
 	y           yresource.Handler
 	newClientFn func(c *gnmitypes.TargetConfig) *target.Target
 	//newClientFn func(ctx context.Context, cfg ndd.Config) (config.ConfigurationClient, error)
+	grpcQueryAddress string
 }
 
 // Connect produces an ExternalClient by:
@@ -331,9 +336,14 @@ func (c *connectorIpamTenantNetworkinstanceIpaddress) Connect(ctx context.Contex
 	log := c.log.WithValues("resource", mg.GetName())
 	log.Debug("Connect")
 
+	query_address := pkgmetav1.PrefixService + "-" + "ipam" + "." + pkgmetav1.NamespaceLocalK8sDNS + strconv.Itoa((pkgmetav1.GnmiServerPort))
+	if c.grpcQueryAddress != "" {
+		query_address = c.grpcQueryAddress
+	}
+
 	cfg := &gnmitypes.TargetConfig{
 		Name:       "dummy",
-		Address:    pkgmetav1.PrefixService + "-" + "ipam" + "." + pkgmetav1.NamespaceLocalK8sDNS + strconv.Itoa((pkgmetav1.GnmiServerPort)),
+		Address:    query_address,
 		Username:   utils.StringPtr("admin"),
 		Password:   utils.StringPtr("admin"),
 		Timeout:    10 * time.Second,

--- a/internal/controllers/ipam/ipamipamtenantnetworkinstanceipprefix_controller.go
+++ b/internal/controllers/ipam/ipamipamtenantnetworkinstanceipprefix_controller.go
@@ -47,6 +47,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	ipamv1alpha1 "github.com/yndd/nddo-ipam/apis/ipam/v1alpha1"
+	"github.com/yndd/nddo-ipam/internal/shared"
 )
 
 const (
@@ -87,7 +88,7 @@ var resourceRefPathsIpamTenantNetworkinstanceIpprefix = []*gnmi.Path{
 //var externalLeafRefIpamTenantNetworkinstanceIpprefix = []*parser.LeafRefGnmi{}
 
 // SetupIpamTenantNetworkinstanceIpprefix adds a controller that reconciles IpamTenantNetworkinstanceIpprefixs.
-func SetupIpamTenantNetworkinstanceIpprefix(mgr ctrl.Manager, o controller.Options, l logging.Logger, poll time.Duration, namespace string, rs *yentry.Entry) (string, chan cevent.GenericEvent, error) {
+func SetupIpamTenantNetworkinstanceIpprefix(mgr ctrl.Manager, o controller.Options, nddcopts *shared.NddControllerOptions) (string, chan cevent.GenericEvent, error) {
 
 	name := managed.ControllerName(ipamv1alpha1.IpamTenantNetworkinstanceIpprefixGroupKind)
 
@@ -96,22 +97,25 @@ func SetupIpamTenantNetworkinstanceIpprefix(mgr ctrl.Manager, o controller.Optio
 	y := initYangIpamTenantNetworkinstanceIpprefix()
 
 	r := managed.NewReconciler(mgr,
-		resource.ManagedKind(ipamv1alpha1.IpamTenantNetworkinstanceIpprefixGroupVersionKind),
-		managed.WithExternalConnecter(&connectorIpamTenantNetworkinstanceIpprefix{
-			log:         l,
-			kube:        mgr.GetClient(),
-			usage:       resource.NewNetworkNodeUsageTracker(mgr.GetClient(), &ndrv1.NetworkNodeUsage{}),
-			rootSchema:  rs,
-			y:           y,
-			newClientFn: target.NewTarget},
+		resource.ManagedKind(ipamv1alpha1.IpamGroupVersionKind),
+		managed.WithExternalConnecter(&connectorIpam{
+			log:              nddcopts.Logger,
+			kube:             mgr.GetClient(),
+			usage:            resource.NewNetworkNodeUsageTracker(mgr.GetClient(), &ndrv1.NetworkNodeUsage{}),
+			rootSchema:       nddcopts.Yentry,
+			y:                y,
+			newClientFn:      target.NewTarget,
+			grpcQueryAddress: nddcopts.GrpcQueryAddress,
+		},
 		),
-		managed.WithParser(l),
-		managed.WithValidator(&validatorIpamTenantNetworkinstanceIpprefix{
-			log:        l,
-			rootSchema: rs,
+		managed.WithParser(nddcopts.Logger),
+		managed.WithValidator(&validatorIpam{
+			log:        nddcopts.Logger,
+			rootSchema: nddcopts.Yentry,
 			y:          y,
-			parser:     *parser.NewParser(parser.WithLogger(l))}),
-		managed.WithLogger(l.WithValues("controller", name)),
+			parser:     *parser.NewParser(parser.WithLogger(nddcopts.Logger))},
+		),
+		managed.WithLogger(nddcopts.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
 
 	return ipamv1alpha1.IpamTenantNetworkinstanceIpprefixGroupKind, events, ctrl.NewControllerManagedBy(mgr).
@@ -320,6 +324,7 @@ type connectorIpamTenantNetworkinstanceIpprefix struct {
 	y           yresource.Handler
 	newClientFn func(c *gnmitypes.TargetConfig) *target.Target
 	//newClientFn func(ctx context.Context, cfg ndd.Config) (config.ConfigurationClient, error)
+	grpcQueryAddress string
 }
 
 // Connect produces an ExternalClient by:
@@ -330,9 +335,15 @@ func (c *connectorIpamTenantNetworkinstanceIpprefix) Connect(ctx context.Context
 	log := c.log.WithValues("resource", mg.GetName())
 	log.Debug("Connect")
 
+	query_address := pkgmetav1.PrefixService + "-" + "ipam" + "." + pkgmetav1.NamespaceLocalK8sDNS + strconv.Itoa((pkgmetav1.GnmiServerPort))
+
+	if c.grpcQueryAddress != "" {
+		query_address = c.grpcQueryAddress
+	}
+
 	cfg := &gnmitypes.TargetConfig{
 		Name:       "dummy",
-		Address:    pkgmetav1.PrefixService + "-" + "ipam" + "." + pkgmetav1.NamespaceLocalK8sDNS + strconv.Itoa((pkgmetav1.GnmiServerPort)),
+		Address:    query_address,
 		Username:   utils.StringPtr("admin"),
 		Password:   utils.StringPtr("admin"),
 		Timeout:    10 * time.Second,

--- a/internal/controllers/ipam/ipamipamtenantnetworkinstanceipprefix_controller.go
+++ b/internal/controllers/ipam/ipamipamtenantnetworkinstanceipprefix_controller.go
@@ -97,8 +97,8 @@ func SetupIpamTenantNetworkinstanceIpprefix(mgr ctrl.Manager, o controller.Optio
 	y := initYangIpamTenantNetworkinstanceIpprefix()
 
 	r := managed.NewReconciler(mgr,
-		resource.ManagedKind(ipamv1alpha1.IpamGroupVersionKind),
-		managed.WithExternalConnecter(&connectorIpam{
+		resource.ManagedKind(ipamv1alpha1.IpamTenantNetworkinstanceIpprefixGroupVersionKind),
+		managed.WithExternalConnecter(&connectorIpamTenantNetworkinstanceIpprefix{
 			log:              nddcopts.Logger,
 			kube:             mgr.GetClient(),
 			usage:            resource.NewNetworkNodeUsageTracker(mgr.GetClient(), &ndrv1.NetworkNodeUsage{}),
@@ -109,7 +109,7 @@ func SetupIpamTenantNetworkinstanceIpprefix(mgr ctrl.Manager, o controller.Optio
 		},
 		),
 		managed.WithParser(nddcopts.Logger),
-		managed.WithValidator(&validatorIpam{
+		managed.WithValidator(&validatorIpamTenantNetworkinstanceIpprefix{
 			log:        nddcopts.Logger,
 			rootSchema: nddcopts.Yentry,
 			y:          y,

--- a/internal/controllers/ipam/ipamipamtenantnetworkinstanceiprange_controller.go
+++ b/internal/controllers/ipam/ipamipamtenantnetworkinstanceiprange_controller.go
@@ -47,6 +47,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	ipamv1alpha1 "github.com/yndd/nddo-ipam/apis/ipam/v1alpha1"
+	"github.com/yndd/nddo-ipam/internal/shared"
 )
 
 const (
@@ -89,7 +90,7 @@ var resourceRefPathsIpamTenantNetworkinstanceIprange = []*gnmi.Path{
 //var externalLeafRefIpamTenantNetworkinstanceIprange = []*parser.LeafRefGnmi{}
 
 // SetupIpamTenantNetworkinstanceIprange adds a controller that reconciles IpamTenantNetworkinstanceIpranges.
-func SetupIpamTenantNetworkinstanceIprange(mgr ctrl.Manager, o controller.Options, l logging.Logger, poll time.Duration, namespace string, rs *yentry.Entry) (string, chan cevent.GenericEvent, error) {
+func SetupIpamTenantNetworkinstanceIprange(mgr ctrl.Manager, o controller.Options, nddcopts *shared.NddControllerOptions) (string, chan cevent.GenericEvent, error) {
 
 	name := managed.ControllerName(ipamv1alpha1.IpamTenantNetworkinstanceIprangeGroupKind)
 
@@ -98,22 +99,25 @@ func SetupIpamTenantNetworkinstanceIprange(mgr ctrl.Manager, o controller.Option
 	y := initYangIpamTenantNetworkinstanceIprange()
 
 	r := managed.NewReconciler(mgr,
-		resource.ManagedKind(ipamv1alpha1.IpamTenantNetworkinstanceIprangeGroupVersionKind),
-		managed.WithExternalConnecter(&connectorIpamTenantNetworkinstanceIprange{
-			log:         l,
-			kube:        mgr.GetClient(),
-			usage:       resource.NewNetworkNodeUsageTracker(mgr.GetClient(), &ndrv1.NetworkNodeUsage{}),
-			rootSchema:  rs,
-			y:           y,
-			newClientFn: target.NewTarget},
+		resource.ManagedKind(ipamv1alpha1.IpamGroupVersionKind),
+		managed.WithExternalConnecter(&connectorIpam{
+			log:              nddcopts.Logger,
+			kube:             mgr.GetClient(),
+			usage:            resource.NewNetworkNodeUsageTracker(mgr.GetClient(), &ndrv1.NetworkNodeUsage{}),
+			rootSchema:       nddcopts.Yentry,
+			y:                y,
+			newClientFn:      target.NewTarget,
+			grpcQueryAddress: nddcopts.GrpcQueryAddress,
+		},
 		),
-		managed.WithParser(l),
-		managed.WithValidator(&validatorIpamTenantNetworkinstanceIprange{
-			log:        l,
-			rootSchema: rs,
+		managed.WithParser(nddcopts.Logger),
+		managed.WithValidator(&validatorIpam{
+			log:        nddcopts.Logger,
+			rootSchema: nddcopts.Yentry,
 			y:          y,
-			parser:     *parser.NewParser(parser.WithLogger(l))}),
-		managed.WithLogger(l.WithValues("controller", name)),
+			parser:     *parser.NewParser(parser.WithLogger(nddcopts.Logger))},
+		),
+		managed.WithLogger(nddcopts.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))))
 
 	return ipamv1alpha1.IpamTenantNetworkinstanceIprangeGroupKind, events, ctrl.NewControllerManagedBy(mgr).
@@ -323,6 +327,7 @@ type connectorIpamTenantNetworkinstanceIprange struct {
 	y           yresource.Handler
 	newClientFn func(c *gnmitypes.TargetConfig) *target.Target
 	//newClientFn func(ctx context.Context, cfg ndd.Config) (config.ConfigurationClient, error)
+	grpcQueryAddress string
 }
 
 // Connect produces an ExternalClient by:
@@ -333,9 +338,15 @@ func (c *connectorIpamTenantNetworkinstanceIprange) Connect(ctx context.Context,
 	log := c.log.WithValues("resource", mg.GetName())
 	log.Debug("Connect")
 
+	query_address := pkgmetav1.PrefixService + "-" + "ipam" + "." + pkgmetav1.NamespaceLocalK8sDNS + strconv.Itoa((pkgmetav1.GnmiServerPort))
+
+	if c.grpcQueryAddress != "" {
+		query_address = c.grpcQueryAddress
+	}
+
 	cfg := &gnmitypes.TargetConfig{
 		Name:       "dummy",
-		Address:    pkgmetav1.PrefixService + "-" + "ipam" + "." + pkgmetav1.NamespaceLocalK8sDNS + strconv.Itoa((pkgmetav1.GnmiServerPort)),
+		Address:    query_address,
 		Username:   utils.StringPtr("admin"),
 		Password:   utils.StringPtr("admin"),
 		Timeout:    10 * time.Second,

--- a/internal/controllers/ipam/ipamipamtenantnetworkinstanceiprange_controller.go
+++ b/internal/controllers/ipam/ipamipamtenantnetworkinstanceiprange_controller.go
@@ -99,8 +99,8 @@ func SetupIpamTenantNetworkinstanceIprange(mgr ctrl.Manager, o controller.Option
 	y := initYangIpamTenantNetworkinstanceIprange()
 
 	r := managed.NewReconciler(mgr,
-		resource.ManagedKind(ipamv1alpha1.IpamGroupVersionKind),
-		managed.WithExternalConnecter(&connectorIpam{
+		resource.ManagedKind(ipamv1alpha1.IpamTenantNetworkinstanceIprangeGroupVersionKind),
+		managed.WithExternalConnecter(&connectorIpamTenantNetworkinstanceIprange{
 			log:              nddcopts.Logger,
 			kube:             mgr.GetClient(),
 			usage:            resource.NewNetworkNodeUsageTracker(mgr.GetClient(), &ndrv1.NetworkNodeUsage{}),
@@ -111,7 +111,7 @@ func SetupIpamTenantNetworkinstanceIprange(mgr ctrl.Manager, o controller.Option
 		},
 		),
 		managed.WithParser(nddcopts.Logger),
-		managed.WithValidator(&validatorIpam{
+		managed.WithValidator(&validatorIpamTenantNetworkinstanceIprange{
 			log:        nddcopts.Logger,
 			rootSchema: nddcopts.Yentry,
 			y:          y,

--- a/internal/shared/shared.go
+++ b/internal/shared/shared.go
@@ -1,0 +1,16 @@
+package shared
+
+import (
+	"time"
+
+	"github.com/yndd/ndd-runtime/pkg/logging"
+	"github.com/yndd/ndd-yang/pkg/yentry"
+)
+
+type NddControllerOptions struct {
+	Logger           logging.Logger
+	Poll             time.Duration
+	Namespace        string
+	Yentry           *yentry.Entry
+	GrpcQueryAddress string
+}


### PR DESCRIPTION
This allows for validation to happen in remote debugging cases.
Basically the address for grpc queries is injected via the "--grpc-query-address" parameter.

Using some kind of ssh config like:

```
  Host server01-kubernetes
      HostName <JumphostExternalIP>
      LocalForward 6443 <k8sAPIIP>:6443
      RemoteForward <JumphostK8sSideIP>:9999 127.0.0.1:9999
```

set the "--grpc-query-address" to `<JumphostK8sSideIP>` and you're good to go.